### PR TITLE
允许指定上级DNS端口

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ run :
 	@$(TARGET)
  
 $(CCOBJSFILE) : 
+	@mkdir -p $(BINDIR) $(BUILDDIR)
 	@echo CCOBJS=`ls $(SRCDIR)/*.c` > $(CCOBJSFILE)
  
 $(TARGET) : $(LDOBJS)

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CCFLAGS=-O3 -Werror -Wall
 LDFLAGS=
  
 SRCDIR=src
-BINDIR=src
-BUILDDIR=src
+BINDIR=bin
+BUILDDIR=build
  
 TARGET=$(BINDIR)/hev-dns-forwarder
 CCOBJSFILE=$(BUILDDIR)/ccobjs
@@ -21,6 +21,9 @@ all : $(CCOBJSFILE) $(TARGET)
  
 clean : 
 	@echo -n "Clean ... " && $(RM) $(TARGET) $(CCOBJSFILE) $(BUILDDIR)/*.dep  $(BUILDDIR)/*.o && echo "OK"
+
+run :
+	@$(TARGET)
  
 $(CCOBJSFILE) : 
 	@echo CCOBJS=`ls $(SRCDIR)/*.c` > $(CCOBJSFILE)

--- a/src/hev-dns-forwarder.c
+++ b/src/hev-dns-forwarder.c
@@ -41,7 +41,7 @@ static void remove_all_sessions (HevDNSForwarder *self);
 
 HevDNSForwarder *
 hev_dns_forwarder_new (HevEventLoop *loop, const char *addr, unsigned short port,
-			const char *upstream)
+			const char *upstream, unsigned short upstream_port)
 {
 	HevDNSForwarder *self = HEV_MEMORY_ALLOCATOR_ALLOC (sizeof (HevDNSForwarder));
 	if (self) {
@@ -92,7 +92,7 @@ hev_dns_forwarder_new (HevEventLoop *loop, const char *addr, unsigned short port
 		memset (&self->upstream, 0, sizeof (self->upstream));
 		self->upstream.sin_family = AF_INET;
 		self->upstream.sin_addr.s_addr = inet_addr (upstream);
-		self->upstream.sin_port = htons (53);
+		self->upstream.sin_port = htons (upstream_port);
 	}
 
 	return self;

--- a/src/hev-dns-forwarder.h
+++ b/src/hev-dns-forwarder.h
@@ -17,7 +17,7 @@ typedef struct _HevDNSForwarder HevDNSForwarder;
 
 HevDNSForwarder * hev_dns_forwarder_new (HevEventLoop *loop,
 			const char *addr, unsigned short port,
-			const char *upstream);
+			const char *upstream, unsigned short upstream_port);
 
 HevDNSForwarder * hev_dns_forwarder_ref (HevDNSForwarder *self);
 void hev_dns_forwarder_unref (HevDNSForwarder *self);

--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -16,7 +16,7 @@
 #include "hev-dns-forwarder.h"
 #include "hev-event-source-signal.h"
 
-static const char *default_dns_servers = "8.8.8.8";
+static const char *default_dns_servers = "8.8.8.8#53";
 static const char *default_listen_addr = "0.0.0.0";
 static const char *default_listen_port = "5300";
 
@@ -29,7 +29,7 @@ Forwarding DNS queries on TCP transport.\n\
 \n\
   -b BIND_ADDR          address that listens, default: 0.0.0.0\n\
   -p BIND_PORT          port that listens, default: 5300\n\
-  -s DNS                DNS servers to use, default: 8.8.8.8\n\
+  -s DNS:[PORT]         DNS servers to use, default: 8.8.8.8:53\n\
   -h                    show this help message and exit\n", app);
 }
 
@@ -52,6 +52,7 @@ main (int argc, char **argv)
 	char *listen_addr = NULL;
 	char *listen_port = NULL;
 	char *dns_servers = NULL;
+	char *dns_port = NULL;
 
 	while ((ch = getopt(argc, argv, "hb:p:s:")) != -1) {
 		switch (ch) {
@@ -90,7 +91,11 @@ main (int argc, char **argv)
 	hev_event_loop_add_source (loop, source);
 	hev_event_source_unref (source);
 
-	forwarder = hev_dns_forwarder_new (loop, listen_addr, atoi(listen_port), dns_servers);
+	// depart server address and server port
+	dns_port = strpbrk(dns_servers, ":#");
+	*dns_port++ = '\0';
+
+	forwarder = hev_dns_forwarder_new (loop, listen_addr, atoi(listen_port), dns_servers, atoi(dns_port));
 	if (forwarder) {
 		hev_event_loop_run (loop);
 		hev_dns_forwarder_unref (forwarder);

--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -17,6 +17,7 @@
 #include "hev-event-source-signal.h"
 
 static const char *default_dns_servers = "8.8.8.8#53";
+static const char *default_dns_port = "53";
 static const char *default_listen_addr = "0.0.0.0";
 static const char *default_listen_port = "5300";
 
@@ -74,6 +75,12 @@ main (int argc, char **argv)
 	if (dns_servers == NULL) {
 		dns_servers = strdup(default_dns_servers);
 	}
+	dns_port = strpbrk(dns_servers, ":#");
+	if(dns_port == NULL){
+		dns_port = strdup(default_dns_port);
+	}else{
+		*dns_port++ = '\0';
+	}
 	if (listen_addr == NULL) {
 		listen_addr = strdup(default_listen_addr);
 	}
@@ -90,10 +97,6 @@ main (int argc, char **argv)
 	hev_event_source_set_callback (source, signal_handler, loop, NULL);
 	hev_event_loop_add_source (loop, source);
 	hev_event_source_unref (source);
-
-	// depart server address and server port
-	dns_port = strpbrk(dns_servers, ":#");
-	*dns_port++ = '\0';
 
 	forwarder = hev_dns_forwarder_new (loop, listen_addr, atoi(listen_port), dns_servers, atoi(dns_port));
 	if (forwarder) {


### PR DESCRIPTION
在指定上级DNS时, 同时允许指定上级DNS的端口, 支持:和#作为分隔符.
这样就可以让DNS-Forwarder将DNS请求转发给SS-Tunnel以支持某些不支持UDP的转发的SS.

在我的网络(教育网)下, 直接通过TCP请求国外DNS也会被阻断.
所以, 需要通过SS-Tunnel转发TCP形式的DNS请求. 

同时, 稍微修改了一下Makefile...意义在于, 解决强迫症= =【分离src, bin和build
需要对openwrt-dns-forwarder的install选项做出修改. 
以及对openwrt-dist-luci中对上级DNS服务的格式限制做出修改. 